### PR TITLE
core: Fix 'different' affinity option

### DIFF
--- a/kubenetbench/core/affinity.go
+++ b/kubenetbench/core/affinity.go
@@ -55,7 +55,7 @@ func (c *RunBenchCtx) cliAffinityWrite(pw *utils.PrefixWriter, params map[string
 		return
 	case c.cliAffinity == "same":
 		cliAffinitySame(pw)
-	case c.cliAffinity == "other":
+	case c.cliAffinity == "different":
 		cliAffinityOther(pw)
 	case strings.HasPrefix(c.cliAffinity, "host="):
 		host := strings.TrimPrefix(c.cliAffinity, "host=")


### PR DESCRIPTION
Code was expecting 'other', but helps says to use 'different'. Stick with 'different' as it's a clearer antonym to 'same'.

Fixes: 6915314 ("add host affinity option")