### PR TITLE
cmd: Make client affinity default to different

### DIFF
--- a/kubenetbench/cmd/run.go
+++ b/kubenetbench/cmd/run.go
@@ -24,7 +24,7 @@ func addBenchmarkFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&runLabel, "run-label", "l", "", "benchmark run label")
 	cmd.Flags().IntVarP(&benchmarkDuration, "duration", "t", 30, "benchmark duration (sec)")
 	cmd.Flags().BoolVar(&noCleanup, "no-cleanup", false, "do not perform cleanup (delete created k8s resources, etc.)")
-	cmd.Flags().StringVar(&cliAffinity, "client-affinity", "none", "client affinity (none, same: same as server, different: different than server, host=XXXX)")
+	cmd.Flags().StringVar(&cliAffinity, "client-affinity", "different", "client affinity (different: different than server, same: same as server, host=XXXX)")
 	cmd.Flags().StringVar(&srvAffinity, "server-affinity", "none", "server affinity (none, host=XXXX)")
 	cmd.Flags().BoolVar(&collectPerf, "collect-perf", false, "collect performance data usning perf")
 	addNetperfFlags(cmd)

--- a/kubenetbench/core/affinity.go
+++ b/kubenetbench/core/affinity.go
@@ -51,8 +51,6 @@ func affinityHost(host string, pw *utils.PrefixWriter) {
 
 func (c *RunBenchCtx) cliAffinityWrite(pw *utils.PrefixWriter, params map[string]interface{}) {
 	switch {
-	case c.cliAffinity == "none":
-		return
 	case c.cliAffinity == "same":
 		cliAffinitySame(pw)
 	case c.cliAffinity == "different":


### PR DESCRIPTION
The previous default was none which doesn't enforce any client affinity. That means tests can produce significantly different results based on whether the pods are on the same node or not.

We likely want to make sure running the same command twice produces the same results (or at least the same test environment) so let's remove 'none' and make 'different' the default.